### PR TITLE
Fix version update via Grav Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.5.0
+## 09/22/2019
+
+* Changes for General Data Protection Regulation (GDPR)
+* Added support for environment variables
+* Add capabilities to block address ranges and use a blocking cookie
+* Opt out code added
+
 # v1.4.0
 ## 01/04/2017
 
@@ -9,7 +17,7 @@
 1. [](#improved)
     * Improve plugin configuration with tab views.
     * Better use and configuration of the global object name. Please use `objectName` instead of `renameGa`. 
-    
+
 # v1.3.0
 ## 12/21/2016
 
@@ -19,14 +27,14 @@
     * Added german translation
 1. [](#bugfix)
     * Fixed the date format in the changelog 
- 
+
 # v1.2.0
 ## 08/11/2016
 
-1. [](#new)    
+1. [](#new)
     * Rename the global (ga) variable of the Google Analytics object
     * Enable the debug version of the analytics.js library + Trace Debugging
-        
+      
 # v1.1.0
 ## 08/02/2016
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.1
+## 03/10/2023
+
+* Fix previously broken 1.5.0 release
+
 # v1.5.0
 ## 09/22/2019
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Google Analytics
-version: 1.5.0
+version: 1.5.1
 description: "Easily integrate and configure Google Analytics without the need to touch any code within your Grav site."
 icon: google
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Google Analytics
-version: 1.4.0
+version: 1.5.0
 description: "Easily integrate and configure Google Analytics without the need to touch any code within your Grav site."
 icon: google
 author:


### PR DESCRIPTION
1.5.0 was actually published as 1.4.0, so if you had 1.4.0 installed previously GPM won't update it.

This patch fixes version in the blueprint and the changelog. Not sure if this will help, or something else must be done. Like, releasing 1.5.1 properly?