### PR TITLE
Fix YAML syntax

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -163,7 +163,7 @@ form:
                   size: large
                   label: PLUGIN_GANALYTICS.OPTOUT_LINK
                   markdown: true
-                  content: `<a href="javascript:gaOptout()">Disable Google Analytics ...</a>`
+                  content: "`<a href=\"javascript:gaOptout()\">Disable Google Analytics ...</a>`"
 
                 optOutEnabled:
                   type: toggle


### PR DESCRIPTION
This issue prevented `bin/gpm direct-install` usage with this plugin.